### PR TITLE
iMX6: Enable secondary cores via PSCI

### DIFF
--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -56,9 +56,13 @@ void arm_cl2_config(vaddr_t pl310);
 void arm_cl2_enable(vaddr_t pl310);
 
 #if defined(CFG_BOOT_SECONDARY_REQUEST)
-extern paddr_t ns_entry_addrs[];
+struct ns_entry_context {
+	paddr_t entry_point;
+	uint32_t r0;
+};
+extern struct ns_entry_context ns_entry_contexts[];
 int generic_boot_core_release(size_t core_idx, paddr_t entry);
-paddr_t generic_boot_core_hpen(void);
+struct ns_entry_context *generic_boot_core_hpen(void);
 #endif
 
 #endif /* KERNEL_GENERIC_BOOT_H */

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -75,7 +75,7 @@
 #define PADDR_INVALID		ULONG_MAX
 
 #if defined(CFG_BOOT_SECONDARY_REQUEST)
-paddr_t ns_entry_addrs[CFG_TEE_CORE_NB_CORE];
+struct ns_entry_context ns_entry_contexts[CFG_TEE_CORE_NB_CORE];
 static uint32_t spin_table[CFG_TEE_CORE_NB_CORE];
 #endif
 
@@ -643,7 +643,7 @@ int generic_boot_core_release(size_t core_idx, paddr_t entry)
 	if (!core_idx || core_idx >= CFG_TEE_CORE_NB_CORE)
 		return -1;
 
-	ns_entry_addrs[core_idx] = entry;
+	ns_entry_contexts[core_idx].entry_point = entry;
 	dmb();
 	spin_table[core_idx] = 1;
 	dsb();
@@ -656,16 +656,16 @@ int generic_boot_core_release(size_t core_idx, paddr_t entry)
  * spin until secondary boot request, then returns with
  * the secondary core entry address.
  */
-paddr_t generic_boot_core_hpen(void)
+struct ns_entry_context *generic_boot_core_hpen(void)
 {
 #ifdef CFG_PSCI_ARM32
-	return ns_entry_addrs[get_core_pos()];
+	return &ns_entry_contexts[get_core_pos()];
 #else
 	do {
 		wfe();
 	} while (!spin_table[get_core_pos()]);
 	dmb();
-	return ns_entry_addrs[get_core_pos()];
+	return &ns_entry_contexts[get_core_pos()];
 #endif
 }
 #endif

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -515,15 +515,18 @@ UNWIND(	.cantunwind)
 	cpu_is_ready
 
 #if defined (CFG_BOOT_SECONDARY_REQUEST)
-	/* generic_boot_core_hpen return value (r0) is ns entry point */
+	/* generic_boot_core_hpen return value (r0) is ns entry context structure */
 	bl	generic_boot_core_hpen
+	ldr	r6, [r0, #4]	/* load nonsecure r0 value to r6 */
+	ldr	r0, [r0, #0]	/* load entry point address to r0 */
 #else
 	mov	r0, r5		/* ns-entry address */
+	mov	r6, #0
 #endif
 	bl	generic_boot_init_secondary
 
 	mov	r0, #TEESMC_OPTEED_RETURN_ENTRY_DONE
-	mov	r1, #0
+	mov	r1, r6		/* r1-r4 get shifted to r0-r3 on nsec return */
 	mov	r2, #0
 	mov	r3, #0
 	mov	r4, #0


### PR DESCRIPTION
Command used to build PSCI-enabled OPTEE:

make PLATFORM=imx-mx6qsabresd CFG_PSCI_ARM32=y CFG_RPMB_FS=y CFG_RPMB_TESTKEY=y CFG_RPMB_RESET_FAT=y CFG_TA_HELLO_WORLD=n CFG_WITH_USER_TA=n CFG_PAGED_USER_TA=n CFG_WITH_PAGER=y CFG_CRYPTO_SIZE_OPTIMIZATION=y platform-cflags-optimization=-Os CFG_UNWIND=n CFG_CYREP=y CFG_TEE_CORE_DEBUG=n CFG_TEE_CORE_LOG_LEVEL=2 CFG_BOOT_SECONDARY_REQUEST=y