### PR TITLE
IMX: don't write to disabled UARTs

### DIFF
--- a/core/arch/arm/plat-imx/config/config_imx7.h
+++ b/core/arch/arm/plat-imx/config/config_imx7.h
@@ -51,11 +51,14 @@
 
 /*
  * Everything is in TZDRAM.
- * +------------------+
- * |        | TEE_RAM |
- * + TZDRAM +---------+
- * |        | TA_RAM  |
- * +--------+---------+
+ *  +---------------------------------------+  <- TZDRAM_BASE
+ *  | TEE private secure |  TEE_RAM         |   ^
+ *  |   external memory  +------------------+   | TZDRAM_SIZE
+ *  |                    |  TA_RAM          |   v
+ *  +---------------------------------------+  <- CFG_SHMEM_START
+ *  |     Non secure     |  SHM             |   ^
+ *  |   shared memory    |                  |   | CFG_SHMEM_SIZE
+ *  +---------------------------------------+   v
  */
 #define CFG_TEE_RAM_PH_SIZE     CFG_TEE_RAM_VA_SIZE
 #define CFG_TEE_RAM_START	TZDRAM_BASE

--- a/core/drivers/imx_uart.c
+++ b/core/drivers/imx_uart.c
@@ -92,6 +92,9 @@ static void imx_uart_flush(struct serial_chip *chip)
 {
 	vaddr_t base = chip_to_base(chip);
 
+	if (!(read32(base + UCR1) & UCR1_UARTEN))
+		return;
+
 	while (!(read32(base + UTS) & UTS_TXEMPTY))
 		;
 }
@@ -109,6 +112,9 @@ static int imx_uart_getchar(struct serial_chip *chip)
 static void imx_uart_putc(struct serial_chip *chip, int ch)
 {
 	vaddr_t base = chip_to_base(chip);
+
+	if (!(read32(base + UCR1) & UCR1_UARTEN))
+		return;
 
 	write32(ch, base + UTXD);
 


### PR DESCRIPTION
Update diagram for imx7 memory layout.
Don't write to disabled iMX UARTs.
