### PR TITLE
Reserve another 16 Mb for OPTEE

### DIFF
--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -174,6 +174,7 @@ struct tzc_encoding {
 };
 
 static struct tzc_encoding tzc_encodings[] = {
+    {64 * 1024 * 1024,  TZC_ATTR_REGION_SIZE(TZC_REGION_SIZE_64M)},
     {32 * 1024 * 1024,  TZC_ATTR_REGION_SIZE(TZC_REGION_SIZE_32M)},
     {16 * 1024 * 1024,  TZC_ATTR_REGION_SIZE(TZC_REGION_SIZE_16M)},
     {8 * 1024 * 1024,   TZC_ATTR_REGION_SIZE(TZC_REGION_SIZE_8M)},

--- a/core/arch/arm/plat-imx/platform_config.h
+++ b/core/arch/arm/plat-imx/platform_config.h
@@ -65,9 +65,9 @@
 #define CFG_DDR_TEETZ_RESERVED_START	0x9E000000
 #endif
 
-#define CFG_DDR_TEETZ_RESERVED_SIZE	0x02000000
+#define CFG_DDR_TEETZ_RESERVED_SIZE	0x03000000
 
-#define CFG_PUB_RAM_SIZE	(2 * 1024 * 1024)
+#define CFG_PUB_RAM_SIZE	(8 * 1024 * 1024)
 
 #define TZDRAM_BASE		(CFG_DDR_TEETZ_RESERVED_START)
 #define TZDRAM_SIZE		(CFG_DDR_TEETZ_RESERVED_SIZE - \
@@ -284,9 +284,10 @@
 /* Location of trusted dram */
 
 #define CFG_DDR_TEETZ_RESERVED_START	0x10A00000
-#define CFG_DDR_TEETZ_RESERVED_SIZE		0x02000000
 
-#define CFG_PUB_RAM_SIZE		(2 * 1024 * 1024)
+#define CFG_DDR_TEETZ_RESERVED_SIZE	0x03000000
+
+#define CFG_PUB_RAM_SIZE		(8 * 1024 * 1024)
 
 
 /* Area reserved for nonpageable part of image */
@@ -315,15 +316,15 @@
  *  |   shared memory    |                  |   |
  *  +---------------------------------------+   v
  *
- *  TEE_RAM : default 1MByte
- *  PUB_RAM : default 2MByte
+ *  TEE_RAM : 2MByte
+ *  PUB_RAM : 8MByte
  *  TA_RAM  : all what is left
  */
 
 #define CFG_DDR_TEETZ_RESERVED_START    0x10A00000
-#define CFG_DDR_TEETZ_RESERVED_SIZE     0x02000000
+#define CFG_DDR_TEETZ_RESERVED_SIZE	0x03000000
 
-#define CFG_PUB_RAM_SIZE		(2 * 1024 * 1024)
+#define CFG_PUB_RAM_SIZE		(8 * 1024 * 1024)
 #define CFG_TEE_RAM_PH_SIZE		(2 * 1024 * 1024)
 
 #define TZDRAM_BASE			(CFG_DDR_TEETZ_RESERVED_START)


### PR DESCRIPTION
This change requires a corresponding change in EDK2-Next.

- Additional 10 Mb of private memory
- Additional 6 Mb of shared memory

This change accomodates larger TAs.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
