### PR TITLE
plat-imx: initialize TZC380

### DIFF
--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -31,6 +31,7 @@
 #include <console.h>
 #include <drivers/gic.h>
 #include <drivers/imx_uart.h>
+#include <drivers/tzc380.h>
 #include <io.h>
 #include <kernel/generic_boot.h>
 #include <kernel/misc.h>
@@ -102,6 +103,11 @@ register_phys_mem(MEM_AREA_IO_SEC,
 		  ROUNDDOWN(PL310_BASE, CORE_MMU_DEVICE_SIZE),
 		  CORE_MMU_DEVICE_SIZE);
 #endif
+#ifdef CFG_TZC380
+register_phys_mem(MEM_AREA_IO_SEC,
+		  ROUNDDOWN(TZASC_BASE, CORE_MMU_DEVICE_SIZE),
+		  CORE_MMU_DEVICE_SIZE);
+#endif
 
 const struct thread_handlers *generic_boot_get_handlers(void)
 {
@@ -142,3 +148,145 @@ void main_secondary_init_gic(void)
 	gic_cpu_init(&gic_data);
 }
 #endif
+
+#ifdef CFG_TZC380
+/* Translation from TZC region sizes to their TZC register encoding values */
+struct tzc_encoding {
+	size_t size_bytes;
+	size_t size_encoding;
+};
+
+static struct tzc_encoding tzc_encodings[] = {
+	{32 * 1024 * 1024,  TZC_ATTR_REGION_SIZE(TZC_REGION_SIZE_32M)},
+	{16 * 1024 * 1024,  TZC_ATTR_REGION_SIZE(TZC_REGION_SIZE_16M)},
+	{8 * 1024 * 1024,   TZC_ATTR_REGION_SIZE(TZC_REGION_SIZE_8M)},
+	{4 * 1024 * 1024,   TZC_ATTR_REGION_SIZE(TZC_REGION_SIZE_4M)},
+	{2 * 1024 * 1024,   TZC_ATTR_REGION_SIZE(TZC_REGION_SIZE_2M)},
+	{1 * 1024 * 1024,   TZC_ATTR_REGION_SIZE(TZC_REGION_SIZE_1M)},
+	{512 * 1024,        TZC_ATTR_REGION_SIZE(TZC_REGION_SIZE_512K)},
+	{256 * 1024,        TZC_ATTR_REGION_SIZE(TZC_REGION_SIZE_256K)},
+	{128 * 1024,        TZC_ATTR_REGION_SIZE(TZC_REGION_SIZE_128K)},
+	{64 * 1024,         TZC_ATTR_REGION_SIZE(TZC_REGION_SIZE_64K)},
+	{32 * 1024,         TZC_ATTR_REGION_SIZE(TZC_REGION_SIZE_32K)},
+};
+
+/* Memory areas reserved just for Secure/TZ access */
+struct secure_area {
+	paddr_t paddr;
+	size_t size_bytes;
+};
+
+static struct secure_area secure_areas[] = {
+#ifdef TZSRAM_BASE
+	{TZSRAM_BASE, TZSRAM_SIZE},
+#endif
+	{TZDRAM_BASE, TZDRAM_SIZE},
+};
+
+static void allow_unsecure_readwrite_entire_memory(void)
+{
+	// Region 0 always includes the entire physical memory.
+	tzc_configure_region(0, 0, TZC_ATTR_SP_ALL);
+}
+
+/* Deny rich OS access to TZ memory */
+static void protect_tz_memory(void)
+{
+	uint8_t secure_index = 0, tzc_index = 0, encoding_index = 0;
+	size_t remaining_bytes = 0, aligned_bytes = 0;
+	uint32_t size_encoding = 0;
+	paddr_t base = 0;
+
+	/* Enable TZC memory region */
+	uint32_t attributes = (TZC_ATTR_REGION_ENABLE << TZC_ATTR_REGION_EN_SHIFT);
+
+	/* Allow just Secure/TZ R+W access, and no access from the rich OS  */
+	attributes |= TZC_ATTR_SP_S_RW;
+
+	/* Region 0 is reserved for the entire physical memory, so start from 1 here */
+	tzc_index = 1;
+
+	/* Secure all TZ memory areas */
+	for (secure_index = 0; secure_index < ARRAY_SIZE(secure_areas); secure_index++) {
+		base = secure_areas[secure_index].paddr;
+		remaining_bytes = secure_areas[secure_index].size_bytes;
+
+		DMSG("pa 0x%08" PRIxPA " size 0x%08zx needs TZC protection",
+				base,
+				remaining_bytes);
+
+		/*
+		 * If this assert fails, add larger TZC region sizes to the
+		 * tzc_encodings array.
+		 */
+		assert(remaining_bytes <= tzc_encodings[0].size_bytes);
+
+		while (remaining_bytes != 0) {
+			/* Find the largest and aligned TZC region size <= remaining_bytes */
+			for (encoding_index = 0;
+					encoding_index < ARRAY_SIZE(tzc_encodings);
+					encoding_index++) {
+
+				aligned_bytes = tzc_encodings[encoding_index].size_bytes;
+
+				if (remaining_bytes >= aligned_bytes) {
+					if ((base < aligned_bytes) || ((base % aligned_bytes) != 0)) {
+						FMSG("Unaligned pa 0x%08" PRIxPA " size 0x%08zx",
+								base,
+								aligned_bytes);
+						continue;
+					}
+
+					/* Found an appropriate TZC region size */
+					size_encoding = tzc_encodings[encoding_index].size_encoding;
+					break;
+				}
+			}
+
+			if (encoding_index >= ARRAY_SIZE(tzc_encodings)) {
+				EMSG("Unsupported TZ memory size = 0x%08zx, unprotected = 0x%08zx",
+						secure_areas[secure_index].size_bytes,
+						remaining_bytes);
+				panic();
+			}
+
+			DMSG("Protecting pa 0x%08" PRIxPA " size 0x%08zx",
+					base,
+					aligned_bytes);
+
+			tzc_configure_region(tzc_index, base, attributes | size_encoding);
+
+			tzc_index++;
+			base += aligned_bytes;
+			remaining_bytes -= aligned_bytes;
+		}
+	}
+}
+
+static TEE_Result init_tzc380(void)
+{
+	void *va;
+
+	va = phys_to_virt(TZASC_BASE, MEM_AREA_IO_SEC);
+	if (!va) {
+		EMSG("TZASC1 not mapped");
+		panic();
+	}
+
+	tzc_init((vaddr_t)va);
+	tzc_set_action(TZC_ACTION_ERR);
+
+	// Start by allowing both TZ and the normal world to read and write, thus
+	// simulating the behavior of systems where the TZASC_ENABLE fuse has not
+	// been burnt.
+	allow_unsecure_readwrite_entire_memory();
+
+	// Reserve some of the memory regions for Secure (TZ) access only.
+	protect_tz_memory();
+
+	return TEE_SUCCESS;
+}
+
+service_init(init_tzc380);
+#endif // #ifdef CFG_TZC380
+

--- a/core/drivers/tzc380.c
+++ b/core/drivers/tzc380.c
@@ -174,7 +174,12 @@ void tzc_configure_region(uint8_t region, vaddr_t region_base, uint32_t attr)
 {
 	assert(tzc.base);
 
-	assert(region < tzc.num_regions);
+	if (region >= tzc.num_regions) {
+		EMSG("region = %u, num_regions = %u", (uint32_t)region,
+			(uint32_t)tzc.num_regions);
+
+		panic();
+	}
 
 	/*
 	 * For region 0, this high/low/size/en field is Read Only (RO).


### PR DESCRIPTION
Initialize trustzone address space controller to allow platforms
with the `TZASC_ENABLE` fuse burnt to boot.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
