### PR TITLE
Modify tee_otp_get_hw_unique_key to return success/failure

### DIFF
--- a/core/arch/arm/kernel/otp_stubs.c
+++ b/core/arch/arm/kernel/otp_stubs.c
@@ -13,9 +13,10 @@
  * The default implementation just sets it to a constant.
  */
 
-__weak void tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
+__weak TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 {
 	memset(&hwkey->data[0], 0, sizeof(hwkey->data));
+	return TEE_SUCCESS;
 }
 
 __weak int tee_otp_get_die_id(uint8_t *buffer, size_t len)

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -185,9 +185,14 @@ void tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 	ret = get_hw_unique_key(OPTEE_SMC_FAST_CALL_SIP_LS_HW_UNQ_KEY,
 			virt_to_phys(hw_unq_key), sizeof(hwkey->data));
 
-	if (ret < 0)
+	if (ret < 0) {
 		EMSG("\nH/W Unique key is not fetched from the platform.");
-	else
+		ret = TEE_ERROR_SECURITY;
+	} else {
 		memcpy(&hwkey->data[0], hw_unq_key, sizeof(hwkey->data));
+		ret = TEE_SUCCESS;
+	}
+
+	return ret;
 }
 #endif

--- a/core/arch/arm/plat-ti/main.c
+++ b/core/arch/arm/plat-ti/main.c
@@ -157,6 +157,7 @@ void console_init(void)
 void tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 {
 	memcpy(&hwkey->data[0], &plat_huk[0], sizeof(hwkey->data));
+	return TEE_SUCCESS;
 }
 
 #endif

--- a/core/include/kernel/tee_common_otp.h
+++ b/core/include/kernel/tee_common_otp.h
@@ -8,13 +8,14 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#include <tee_api_types.h>
 #include <utee_defines.h>
 
 struct tee_hw_unique_key {
 	uint8_t data[HW_UNIQUE_KEY_LENGTH];
 };
 
-void tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey);
+TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey);
 int tee_otp_get_die_id(uint8_t *buffer, size_t len);
 
 #endif /* TEE_COMMON_OTP_H */

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -281,17 +281,13 @@ out:
  *
  * Maybe tee_get_hw_unique_key() should be exposed as
  * generic API for getting hw unique key!
- * We should change the API tee_otp_get_hw_unique_key()
- * to return error code!
  */
 static TEE_Result tee_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 {
 	if (!hwkey)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	tee_otp_get_hw_unique_key(hwkey);
-
-	return TEE_SUCCESS;
+	return tee_otp_get_hw_unique_key(hwkey);
 }
 
 static TEE_Result tee_rpmb_key_gen(uint16_t dev_id __unused,


### PR DESCRIPTION
As per the discussion on line 282 of tee_rpmb_fs.c, it is valuable to know if a hardware unique key is valid before writing it to RPMB.

tee_otp_get_hw_unique_key() should now return TEE_SUCCESS if the key it is returning is valid. During RPMB initialization a bad return from this function will stop the RPMB key from being written if CFG_RPMB_WRITE_KEY=y.

Existing platforms which utilize hardware unique keys have been updated to return appropriate values.
