### PR TITLE
cyres: fix memory leak of rsa_key

### DIFF
--- a/core/arch/arm/pta/pta_cyres.c
+++ b/core/arch/arm/pta/pta_cyres.c
@@ -83,6 +83,7 @@ static TEE_Result get_calling_ta_session(struct tee_ta_session **sess)
 static TEE_Result export_ta_pub_key(unsigned char *buf, unsigned long *len)
 {
 	rsa_key key;
+	TEE_Result res;
 	int ret;
 	uint32_t e = TEE_U32_TO_BIG_ENDIAN(ta_pub_key_exponent);
 
@@ -99,10 +100,15 @@ static TEE_Result export_ta_pub_key(unsigned char *buf, unsigned long *len)
 	ret = rsa_export(buf, len, PK_PUBLIC, &key);
 	if (ret != CRYPT_OK) {
 		DMSG("rsa_export failed (0x%x)", ret);
-		return TEE_ERROR_SECURITY;
+		res = TEE_ERROR_SECURITY;
+		goto end;
 	}
 
-	return TEE_SUCCESS;
+	res = TEE_SUCCESS;
+
+end:
+	rsa_free(&key);
+	return res;
 }
 
 static TEE_Result gen_ta_cert(struct cyres_pta_sess_ctx *ctx)


### PR DESCRIPTION
Missing call to rsa_free() was causing corruption that eventually
caused crash.

Signed-off-by: Jordan Rhee <jordanrh@microsoft.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
