### PR TITLE
Add Tpm vendor prop, die_id to iMX

### DIFF
--- a/core/arch/arm/plat-imx/sub.mk
+++ b/core/arch/arm/plat-imx/sub.mk
@@ -23,3 +23,5 @@ endif
 srcs-$(CFG_MX7) += imx7.c a7_plat_init.S
 
 subdirs-$(CFG_PSCI_ARM32) += pm
+
+srcs-$(CFG_WITH_USER_TA) += vendor_props.c

--- a/core/arch/arm/plat-imx/vendor_props.c
+++ b/core/arch/arm/plat-imx/vendor_props.c
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2016, Linaro Limited.
+ */
+#include <tee/tee_svc.h>
+#include <user_ta_header.h>
+#include <util.h>
+#include <kernel/tee_ta_manager.h>
+#include <kernel/tee_common_otp.h>
+#include <tee/tee_cryp_utl.h>
+
+/*
+ * The data to hash is 64 bytes made up of:
+ * - 16 bytes: the UUID of the calling TA.
+ * - 16 bytes: the hardware unique key
+ * - 32 bytes: the die ID
+ *
+ * For future-proofing the resulting seed is hashed to 64 bytes.
+ */
+static TEE_Result get_prop_endorsement(struct tee_ta_session *sess,
+				       void *buf, size_t *blen)
+{
+	const uint32_t algo = TEE_ALG_SHA512;
+	void *ctx = NULL;
+	uint8_t die_id[TEE_SHA256_HASH_SIZE];
+	uint8_t digest[TEE_SHA512_HASH_SIZE];
+	TEE_Result res;
+	struct tee_hw_unique_key hwkey;
+	const TEE_UUID *uuid;
+
+	EMSG("Generating a new endorsement seed for the fTPM");
+
+	if (*blen < sizeof(digest)) {
+		*blen = sizeof(digest);
+		res = TEE_ERROR_SHORT_BUFFER;
+		goto out;
+	}
+	*blen = sizeof(digest);
+
+	// Generate a new endorsement seed
+	res = crypto_hash_alloc_ctx(&ctx, algo);
+	if (res)
+		goto out;
+
+	res = crypto_hash_init(ctx, algo);
+	if (res)
+		goto out;
+	
+	// Gather the data to hash
+	uuid = &(sess->ctx->uuid);
+	res = crypto_hash_update(ctx, algo, (uint8_t*)uuid, sizeof(*uuid));
+	if (res)
+		goto out;
+
+	res = tee_otp_get_hw_unique_key(&hwkey);
+	if (res)
+		goto out;
+	res = crypto_hash_update(ctx, algo, (uint8_t*)&hwkey, sizeof(hwkey));
+	if (res)
+		goto out;
+
+	res = tee_otp_get_die_id(die_id, sizeof(die_id));
+	if (res)
+		goto out;
+	res = crypto_hash_update(ctx, algo, (uint8_t*)die_id, sizeof(die_id));
+	if (res)
+		goto out;
+
+	res = crypto_hash_final(ctx, algo, digest, sizeof(digest));
+	if (res)
+		goto out;
+
+out:
+	if (ctx)
+		crypto_hash_free_ctx(ctx, algo);
+
+	if (res)
+		return res;
+	else
+		return tee_svc_copy_to_user((void *)buf, digest, sizeof(digest));
+}
+
+static const struct tee_props vendor_propset_array_tee[] = {
+	{
+		.name = "com.microsoft.ta.endorsementSeed",
+		.prop_type = USER_TA_PROP_TYPE_BINARY_BLOCK,
+		.get_prop_func = get_prop_endorsement
+	},
+};
+
+const struct tee_vendor_props vendor_props_tee = {
+	.props = vendor_propset_array_tee,
+	.len = ARRAY_SIZE(vendor_propset_array_tee),
+};

--- a/core/arch/arm/plat-imx/vendor_props.c
+++ b/core/arch/arm/plat-imx/vendor_props.c
@@ -24,9 +24,9 @@ static TEE_Result get_prop_endorsement(struct tee_ta_session *sess,
 	void *ctx = NULL;
 	uint8_t die_id[TEE_SHA256_HASH_SIZE];
 	uint8_t digest[TEE_SHA512_HASH_SIZE];
-	TEE_Result res;
-	struct tee_hw_unique_key hwkey;
-	const TEE_UUID *uuid;
+	struct tee_hw_unique_key hwkey = {0};
+	TEE_Result res = TEE_SUCCESS;
+	const TEE_UUID *uuid = NULL;
 
 	EMSG("Generating a new endorsement seed for the fTPM");
 

--- a/core/arch/arm/plat-imx/vendor_props.c
+++ b/core/arch/arm/plat-imx/vendor_props.c
@@ -45,24 +45,24 @@ static TEE_Result get_prop_endorsement(struct tee_ta_session *sess,
 	res = crypto_hash_init(ctx, algo);
 	if (res)
 		goto out;
-	
+
 	// Gather the data to hash
 	uuid = &(sess->ctx->uuid);
-	res = crypto_hash_update(ctx, algo, (uint8_t*)uuid, sizeof(*uuid));
+	res = crypto_hash_update(ctx, algo, (uint8_t *)uuid, sizeof(*uuid));
 	if (res)
 		goto out;
 
 	res = tee_otp_get_hw_unique_key(&hwkey);
 	if (res)
 		goto out;
-	res = crypto_hash_update(ctx, algo, (uint8_t*)&hwkey, sizeof(hwkey));
+	res = crypto_hash_update(ctx, algo, (uint8_t *)&hwkey, sizeof(hwkey));
 	if (res)
 		goto out;
 
 	res = tee_otp_get_die_id(die_id, sizeof(die_id));
 	if (res)
 		goto out;
-	res = crypto_hash_update(ctx, algo, (uint8_t*)die_id, sizeof(die_id));
+	res = crypto_hash_update(ctx, algo, (uint8_t *)die_id, sizeof(die_id));
 	if (res)
 		goto out;
 

--- a/core/drivers/fsl_sec/hw_key_blob.c
+++ b/core/drivers/fsl_sec/hw_key_blob.c
@@ -12,6 +12,7 @@
 #include "jobdesc.h"
 #include "malloc.h"
 #include "string.h"
+#include <tee/tee_cryp_utl.h>
 
 //-----------------------------------------------------------------------------
 
@@ -144,6 +145,12 @@ TEE_Result get_hw_unq_key_blob_hw(uint8_t *hw_key, int size)
 	// Remove static once free implementation is available
 	static struct job_descriptor *jobdesc;
 
+	// The only useful data is the BKEK, which composes the
+	// first 32 bytes.
+	if (size > KEY_BLOB_SIZE) {
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
 	key_data = memalign(64, key_sz);
 
 	if (key_data == NULL) {
@@ -217,6 +224,7 @@ clean_up:
 TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 {
 	TEE_Result res;
+	uint8_t temp_buffer[KEY_BLOB_SIZE];
 
 	res = init_and_roll_forward_master_key();
 	if (res != TEE_SUCCESS) {
@@ -224,12 +232,49 @@ TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 		return res;
 	}
 
-	res = get_hw_unq_key_blob_hw(&hwkey->data[0], HW_UNIQUE_KEY_LENGTH);
+	// Use the first 16 bytes for the HUK, the last 16 for the die ID.
+	res = get_hw_unq_key_blob_hw(temp_buffer, KEY_BLOB_SIZE);
+	memcpy(&hwkey->data[0], temp_buffer, HW_UNIQUE_KEY_LENGTH);
 
 	if (res != TEE_SUCCESS) {
 		EMSG("Hardware Unique Key Failed");
 	} else {
 		DMSG("Hardware Unique Key Retrieved:");
+	}
+
+	return res;
+}
+
+int tee_otp_get_die_id(uint8_t *buffer, size_t len)
+{
+	TEE_Result res;
+	uint8_t temp_buffer[KEY_BLOB_SIZE];
+	uint8_t *remaining_buffer = &(temp_buffer[HW_UNIQUE_KEY_LENGTH]);
+	uint32_t remaining_size = KEY_BLOB_SIZE - HW_UNIQUE_KEY_LENGTH;
+
+	// Make sure there is some data left available after taking the HUK.
+	COMPILE_TIME_ASSERT(KEY_BLOB_SIZE > HW_UNIQUE_KEY_LENGTH);
+
+	if (len > TEE_SHA256_HASH_SIZE) {
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	res = init_and_roll_forward_master_key();
+	if (res != TEE_SUCCESS) {
+		EMSG("Failed to init normal priblob otpmk identity from CAAM");
+		return res;
+	}
+
+	// Use the first 16 bytes for the HUK, the last 16 for the die ID.
+	res = get_hw_unq_key_blob_hw(temp_buffer, KEY_BLOB_SIZE);
+
+	res = tee_hash_createdigest(TEE_ALG_SHA256, remaining_buffer, remaining_size,
+				buffer, len);
+
+	if (res != TEE_SUCCESS) {
+		EMSG("Die ID Failed");
+	} else {
+		DMSG("Die ID Retrieved:");
 	}
 
 	return res;

--- a/core/drivers/fsl_sec/hw_key_blob.c
+++ b/core/drivers/fsl_sec/hw_key_blob.c
@@ -230,7 +230,6 @@ TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 		EMSG("Hardware Unique Key Failed");
 	} else {
 		DMSG("Hardware Unique Key Retrieved:");
-		DHEXDUMP(&hwkey->data[0], HW_UNIQUE_KEY_LENGTH);
 	}
 
 	return res;

--- a/core/drivers/fsl_sec/hw_key_blob.c
+++ b/core/drivers/fsl_sec/hw_key_blob.c
@@ -230,6 +230,13 @@ TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 	res = init_and_roll_forward_master_key();
 	if (res != TEE_SUCCESS) {
 		EMSG("Failed to init normal priblob otpmk identity from CAAM");
+#ifdef CFG_RPMB_TESTKEY
+		EMSG("\t**** tee_otp_get_hw_unique_key() is INSECURE! ****");
+		EMSG("\t**** CAAM not available (HAB not enabled?) ****");
+		EMSG("\t**** Returning zero buffer because CFG_RPMB_TESTKEY=y ****");
+		memset(&hwkey->data[0], 0, HW_UNIQUE_KEY_LENGTH);
+		res = TEE_SUCCESS;
+#endif
 		goto out;
 	}
 
@@ -243,9 +250,9 @@ TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 
 out:
 	if (res != TEE_SUCCESS)
-		EMSG("Hardware Unique Key Failed");
+		EMSG("Hardware Unique Key failed");
 	else
-		DMSG("Hardware Unique Key Retrieved:");
+		DMSG("Hardware Unique Key retrieved");
 
 	return res;
 }
@@ -268,6 +275,13 @@ int tee_otp_get_die_id(uint8_t *buffer, size_t len)
 	res = init_and_roll_forward_master_key();
 	if (res != TEE_SUCCESS) {
 		EMSG("Failed to init normal priblob otpmk identity from CAAM");
+#ifdef CFG_RPMB_TESTKEY
+		EMSG("\t**** tee_otp_get_die_id() is INSECURE! ****");
+		EMSG("\t**** CAAM not available (HAB not enabled?) ****");
+		EMSG("\t**** Returning zero buffer because CFG_RPMB_TESTKEY=y ****");
+		memset(buffer, 0, len);
+		res = TEE_SUCCESS;
+#endif
 		goto out;
 	}
 
@@ -277,14 +291,14 @@ int tee_otp_get_die_id(uint8_t *buffer, size_t len)
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	res = tee_hash_createdigest(TEE_ALG_SHA256, remaining_buffer, remaining_size,
-				buffer, len);
+	res = tee_hash_createdigest(TEE_ALG_SHA256, remaining_buffer,
+				remaining_size, buffer, len);
 
 out:
 	if (res != TEE_SUCCESS)
-		EMSG("Die ID Failed");
+		EMSG("Die ID failed");
 	else
-		DMSG("Die ID Retrieved:");
+		DMSG("Die ID retrieved");
 
 	return res;
 }


### PR DESCRIPTION
Vendor properties are extra properties which can be added to a specific platform. In this case MSR added a "com.microsoft.ta.endorsementSeed" back in ~2015-16. This property generates a unique ID for the TA which is tied to the underlying hardware.

In the case of the original implementation it appears they were targeting by die ID which probably implies each family of devices would end up with the same endorsement seeds. For our use case we prefer to have unique seeds for every device.

To improve the quality of the keys generated `tee_otp_get_die_id()` was implemented for iMX. This consumes the second half of the BKEK which is left unused by `tee_otp_get_hw_unique_key()`. The weak implementation currently in use uses 'beef' repeated as needed.

This change **WILL break** any RPMB keys which have been generated from hardware ID and fused. Test keys should remain uneffected, although previously encrypted data may need to be cleared from RPMB since OP-TEE uses `tee_otp_get_die_id()` to generate a number of keys.

Signed-off-by: Daniel McIlvaney <damcilva@microsoft.com>