### PR TITLE
Add binary measurements to user TA loading

### DIFF
--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -41,14 +41,7 @@ SLIST_HEAD(load_seg_head, load_seg);
  * @ta_time_offs:	Time reference used by the TA
  * @areas:		Memory areas registered by pager
  * @vfp:		State of VFP registers
- * @dynamic_measurement	A running hash of all binary components loaded,
- *			including runtime dynamic libraries
- * @static_measurement	A measurement of the TA as it existed when execution
- *			started (first session start)
- * @is_measured		True if the static measurement has been set
- * @ta_version		The TA version as defined in the shdr_bootstrap_ta
- *			bootstrap header
- * @signer_measurement	Hash of the signing key used to verify the TA
+ * @attestation_data:	Measurements of this TA used for attestation
  * @ctx:		Generic TA context
  */
 struct user_ta_ctx {
@@ -74,11 +67,7 @@ struct user_ta_ctx {
 	struct thread_user_vfp_state vfp;
 #endif
 #ifdef CFG_ATTESTATION_MEASURE
-	uint8_t dynamic_measurement[ATTESTATION_MEASUREMENT_SIZE];
-	uint8_t static_measurement[ATTESTATION_MEASUREMENT_SIZE];
-	bool is_measured;
-	uint32_t ta_version;
-	uint8_t signer_measurement[ATTESTATION_MEASUREMENT_SIZE];
+	struct tee_attestation_data attestation_data;
 #endif
 	struct tee_ta_ctx ctx;
 

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -12,6 +12,7 @@
 #include <mm/tee_mm.h>
 #include <scattered_array.h>
 #include <tee_api_types.h>
+#include <tee/attestation.h>
 #include <types_ext.h>
 #include <util.h>
 
@@ -40,6 +41,14 @@ SLIST_HEAD(load_seg_head, load_seg);
  * @ta_time_offs:	Time reference used by the TA
  * @areas:		Memory areas registered by pager
  * @vfp:		State of VFP registers
+ * @dynamic_measurement	A running hash of all binary components loaded,
+ *			including runtime dynamic libraries
+ * @static_measurement	A measurement of the TA as it existed when execution
+ *			started (first session start)
+ * @is_measured		True if the static measurement has been set
+ * @ta_version		The TA version as defined in the shdr_bootstrap_ta
+ *			bootstrap header
+ * @signer_measurement	Hash of the signing key used to verify the TA
  * @ctx:		Generic TA context
  */
 struct user_ta_ctx {
@@ -63,6 +72,13 @@ struct user_ta_ctx {
 	struct tee_pager_area_head *areas;
 #if defined(CFG_WITH_VFP)
 	struct thread_user_vfp_state vfp;
+#endif
+#ifdef CFG_ATTESTATION_MEASURE
+	uint8_t dynamic_measurement[ATTESTATION_MEASUREMENT_SIZE];
+	uint8_t static_measurement[ATTESTATION_MEASUREMENT_SIZE];
+	bool is_measured;
+	uint32_t ta_version;
+	uint8_t signer_measurement[ATTESTATION_MEASUREMENT_SIZE];
 #endif
 	struct tee_ta_ctx ctx;
 

--- a/core/arch/arm/kernel/early_ta.c
+++ b/core/arch/arm/kernel/early_ta.c
@@ -10,7 +10,6 @@
 #include <kernel/user_ta_store.h>
 #include <stdio.h>
 #include <string.h>
-#include <tee/attestation.h>
 #include <trace.h>
 #include <utee_defines.h>
 #include <util.h>
@@ -127,11 +126,11 @@ static TEE_Result early_ta_get_tag(const struct user_ta_store_handle *h,
 	res = crypto_hash_init(ctx, TEE_ALG_SHA256);
 	if (res)
 		goto out;
-	res = crypto_hash_update(ctx, TEE_ALG_SHA256, h->early_ta->ta + h->offs,
+	res = crypto_hash_update(ctx, TEE_ALG_SHA256, h->early_ta->ta,
 				 h->early_ta->size);
 	if (res)
 		goto out;
-	res = crypto_hash_final(ctx, TEE_ALG_SHA256, tag, h->early_ta->size);
+	res = crypto_hash_final(ctx, TEE_ALG_SHA256, tag, *tag_len);
 out:
 	crypto_hash_free_ctx(ctx, TEE_ALG_SHA256);
 	return res;

--- a/core/arch/arm/kernel/early_ta.c
+++ b/core/arch/arm/kernel/early_ta.c
@@ -10,6 +10,7 @@
 #include <kernel/user_ta_store.h>
 #include <stdio.h>
 #include <string.h>
+#include <tee/attestation.h>
 #include <trace.h>
 #include <utee_defines.h>
 #include <util.h>
@@ -230,6 +231,50 @@ static void early_ta_close(struct user_ta_store_handle *h)
 	free(h);
 }
 
+#ifdef CFG_ATTESTATION_MEASURE
+/*
+ * Early TAs do not include a signed header, and as such will have
+ * different measurements to a normal user TA.
+ */
+static TEE_Result early_ta_get_measurement(struct user_ta_store_handle *h,
+					   uint8_t *binary_measurement,
+					   size_t *measurement_len)
+{
+	return early_ta_get_tag(h, binary_measurement, measurement_len);
+}
+
+/*
+ * Early TAs are not signed, return a zeroed buffer to indicate this.
+ */
+static TEE_Result early_ta_get_signer(struct user_ta_store_handle *h __unused,
+				      uint8_t *signer_measurement,
+				      size_t *measurement_len)
+{
+	if (!signer_measurement ||
+	    *measurement_len < ATTESTATION_MEASUREMENT_SIZE) {
+		*measurement_len = ATTESTATION_MEASUREMENT_SIZE;
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+	*measurement_len = ATTESTATION_MEASUREMENT_SIZE;
+
+	memset(signer_measurement, 0, *measurement_len);
+	return TEE_SUCCESS;
+}
+
+/*
+ * Early TAs are not versioned, return a zero to indicate this.
+ */
+static TEE_Result early_ta_get_version(struct user_ta_store_handle *h __unused,
+				       uint32_t *version)
+{
+	if (!version)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	*version = 0;
+	return TEE_SUCCESS;
+}
+#endif /* CFG_ATTESTATION_MEASURE */
+
 TEE_TA_REGISTER_TA_STORE(2) = {
 	.description = "early TA",
 	.open = early_ta_open,
@@ -237,6 +282,11 @@ TEE_TA_REGISTER_TA_STORE(2) = {
 	.get_tag = early_ta_get_tag,
 	.read = early_ta_read,
 	.close = early_ta_close,
+#ifdef CFG_ATTESTATION_MEASURE
+	.get_measurement = early_ta_get_measurement,
+	.get_version = early_ta_get_version,
+	.get_signer = early_ta_get_signer,
+#endif
 };
 
 static TEE_Result early_ta_init(void)

--- a/core/arch/arm/kernel/secstor_ta.c
+++ b/core/arch/arm/kernel/secstor_ta.c
@@ -9,7 +9,6 @@
 #include <initcall.h>
 #include <crypto/crypto.h>
 #include <ta_pub_key.h>
-#include <tee/attestation.h>
 
 static TEE_Result secstor_ta_open(const TEE_UUID *uuid,
 				  struct user_ta_store_handle **handle)

--- a/core/arch/arm/kernel/secstor_ta.c
+++ b/core/arch/arm/kernel/secstor_ta.c
@@ -7,6 +7,9 @@
 #include <kernel/user_ta.h>
 #include <kernel/user_ta_store.h>
 #include <initcall.h>
+#include <crypto/crypto.h>
+#include <ta_pub_key.h>
+#include <tee/attestation.h>
 
 static TEE_Result secstor_ta_open(const TEE_UUID *uuid,
 				  struct user_ta_store_handle **handle)
@@ -77,6 +80,73 @@ static void secstor_ta_close(struct user_ta_store_handle *h)
 	tee_tadb_ta_close(ta);
 }
 
+#ifdef CFG_ATTESTATION_MEASURE
+static TEE_Result secstor_ta_get_measurement(struct user_ta_store_handle *h,
+					     uint8_t *binary_measurement,
+					     size_t *measurement_len)
+{
+	struct tee_tadb_ta_read *ta = (struct tee_tadb_ta_read *)h;
+
+	return tee_tadb_get_measurement(ta, binary_measurement,
+					measurement_len);
+}
+
+static TEE_Result secstor_ta_get_signer(struct user_ta_store_handle *h __unused,
+					uint8_t *signer_measurement,
+					size_t *measurement_len)
+{
+	uint32_t hash_algo = ATTESTATION_MEASUREMENT_ALGO;
+	void *hash_ctx = NULL;
+	TEE_Result res = TEE_SUCCESS;
+
+	if (!signer_measurement ||
+	    *measurement_len < ATTESTATION_MEASUREMENT_SIZE) {
+		*measurement_len = ATTESTATION_MEASUREMENT_SIZE;
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+	*measurement_len = ATTESTATION_MEASUREMENT_SIZE;
+
+	res = crypto_hash_alloc_ctx(&hash_ctx, hash_algo);
+	if (res != TEE_SUCCESS)
+		goto error_free_hash;
+
+	res = crypto_hash_init(hash_ctx, hash_algo);
+	if (res != TEE_SUCCESS)
+		goto error_free_hash;
+
+	res = crypto_hash_update(hash_ctx, hash_algo,
+				 (uint8_t *)&ta_pub_key_exponent,
+				 sizeof(ta_pub_key_exponent));
+	if (res != TEE_SUCCESS)
+		goto error_free_hash;
+
+	res = crypto_hash_update(hash_ctx, hash_algo,
+				 (uint8_t *)ta_pub_key_modulus,
+				 ta_pub_key_modulus_size);
+	if (res != TEE_SUCCESS)
+		goto error_free_hash;
+
+	res = crypto_hash_final(hash_ctx, hash_algo,
+				signer_measurement,
+				ATTESTATION_MEASUREMENT_SIZE);
+error_free_hash:
+	crypto_hash_free_ctx(hash_ctx, hash_algo);
+	return res;
+}
+
+static TEE_Result secstor_ta_get_version(struct user_ta_store_handle *h,
+					 uint32_t *version)
+{
+	struct tee_tadb_ta_read *ta = (struct tee_tadb_ta_read *)h;
+
+	if (!version)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	*version = tee_tadb_get_version(ta);
+	return TEE_SUCCESS;
+}
+#endif /* CFG_ATTESTATION_MEASURE */
+
 TEE_TA_REGISTER_TA_STORE(4) = {
 	.description = "Secure Storage TA",
 	.open = secstor_ta_open,
@@ -84,4 +154,9 @@ TEE_TA_REGISTER_TA_STORE(4) = {
 	.get_tag = secstor_ta_get_tag,
 	.read = secstor_ta_read,
 	.close = secstor_ta_close,
+#ifdef CFG_ATTESTATION_MEASURE
+	.get_measurement = secstor_ta_get_measurement,
+	.get_version = secstor_ta_get_version,
+	.get_signer = secstor_ta_get_signer,
+#endif
 };

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -146,6 +146,10 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 	usr_params = (struct utee_params *)usr_stack;
 	init_utee_param(usr_params, param, param_va);
 
+#ifdef CFG_ATTESTATION_MEASURE
+	assert(utc->is_measured);
+#endif
+
 	res = thread_enter_user_mode(func, tee_svc_kaddr_to_uref(session),
 				     (vaddr_t)usr_params, cmd, usr_stack,
 				     utc->entry_func, utc->is_32bit,
@@ -276,6 +280,25 @@ static TEE_Result user_ta_enter_open_session(struct tee_ta_session *s,
 			return res;
 		}
 		utc->is_initializing = false;
+#ifdef CFG_ATTESTATION_MEASURE
+		/*
+		 * Capture a static snapshot of the TA before the first
+		 * session begins executing code. Subsequent calls to dlopen
+		 * and related will update the dynamic measurement but not
+		 * this static version.
+		 */
+		assert(!utc->is_measured);
+
+		utc->is_measured = true;
+		memcpy(utc->static_measurement,
+		       utc->dynamic_measurement,
+		       sizeof(utc->dynamic_measurement));
+
+		DMSG("Static measurement of user TA %pUl done:",
+		     (void *)&utc->ctx.uuid);
+		DHEXDUMP(utc->static_measurement,
+			 sizeof(utc->static_measurement));
+#endif /* CFG_ATTESTATION_MEASURE */
 	}
 
 	return user_ta_enter(eo, s, UTEE_ENTRY_FUNC_OPEN_SESSION, 0, param);

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -147,7 +147,7 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 	init_utee_param(usr_params, param, param_va);
 
 #ifdef CFG_ATTESTATION_MEASURE
-	assert(utc->is_measured);
+	assert(utc->attestation_data.is_measured);
 #endif
 
 	res = thread_enter_user_mode(func, tee_svc_kaddr_to_uref(session),
@@ -287,17 +287,17 @@ static TEE_Result user_ta_enter_open_session(struct tee_ta_session *s,
 		 * and related will update the dynamic measurement but not
 		 * this static version.
 		 */
-		assert(!utc->is_measured);
+		assert(!utc->attestation_data.is_measured);
 
-		utc->is_measured = true;
-		memcpy(utc->static_measurement,
-		       utc->dynamic_measurement,
-		       sizeof(utc->dynamic_measurement));
+		utc->attestation_data.is_measured = true;
+		memcpy(utc->attestation_data.static_measurement,
+		       utc->attestation_data.dynamic_measurement,
+		       sizeof(utc->attestation_data.dynamic_measurement));
 
 		DMSG("Static measurement of user TA %pUl done:",
 		     (void *)&utc->ctx.uuid);
-		DHEXDUMP(utc->static_measurement,
-			 sizeof(utc->static_measurement));
+		DHEXDUMP(utc->attestation_data.static_measurement,
+			 sizeof(utc->attestation_data.static_measurement));
 #endif /* CFG_ATTESTATION_MEASURE */
 	}
 

--- a/core/include/kernel/user_ta_store.h
+++ b/core/include/kernel/user_ta_store.h
@@ -49,6 +49,28 @@ struct user_ta_store_ops {
 	 * Close a TA handle. Do nothing if @h == NULL.
 	 */
 	void (*close)(struct user_ta_store_handle *h);
+#ifdef CFG_ATTESTATION_MEASURE
+	/*
+	 * Return the measurement of the binary being loaded in the form of a
+	 * ATTESTATION_MEASUREMENT_ALGO hash.
+	 */
+	TEE_Result (*get_measurement)(struct user_ta_store_handle *h,
+				      uint8_t *binary_measurement,
+				      size_t *measurement_len);
+	/*
+	 * Return the measurement of the signing key used to validate the TA
+	 * in the form of a ATTESTATION_MEASUREMENT_ALGO hash.
+	 */
+	TEE_Result (*get_signer)(struct user_ta_store_handle *h,
+				 uint8_t *signer_measurement,
+				 size_t *measurement_len);
+	/*
+	 * Return the version of the binary as set in the shdr_bootstrap_ta
+	 * header.
+	 */
+	TEE_Result (*get_version)(struct user_ta_store_handle *h,
+				  uint32_t *version);
+#endif /* CFG_ATTESTATION_MEASURE */
 };
 
 #endif /*__KERNEL_USER_TA_STORE_H*/

--- a/core/include/tee/attestation.h
+++ b/core/include/tee/attestation.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2017, Linaro Limited
+ */
+
+#ifndef __TEE_ATTESTATION_H
+#define __TEE_ATTESTATION_H
+
+/* 
+ * Attestation of user TAs in OP-TEE is done via code measurement at load
+ * time. If CFG_ATTESTATION_MEASURE is enabled the System PTA will request
+ * a hash from the user TA store. Each time a new binary is loaded (ie 
+ * shared libraries) for a given TA context the existing measurement is 
+ * combined with the incoming measurement to form a new hash. The
+ * measurement is dependent on the order in which binaries are loaded. A 
+ * copy of the running measurement is frozen before the first session to
+ * the TA is opened.
+ * 
+ * Run Time Binary Loading:
+ * The system PTA offers the option to load binaries after a TA has started
+ * running (dlopen etc). This poses an interesting challenge for attestation
+ * since the original measurement will no longer be valid.
+ * 
+ * TODO: Flesh out this description
+ * 
+ * Issues:
+ * 
+ * - Inconsistent Measurements
+ * Secstor and Ree FS TAs are not measured the same as Early TAs. Early TAs do
+ * not include any headers when they are encoded into the OP-TEE binary and
+ * are a simple hash over the .elf being loaded. The other user TA measurements
+ * are based on the existing verification flow and include parts of the TA
+ * headers.
+ * 
+ */
+
+#define ATTESTATION_MEASUREMENT_SIZE TEE_SHA256_HASH_SIZE
+#define ATTESTATION_MEASUREMENT_ALGO TEE_ALG_SHA256
+
+#endif /* __TEE_ATTESTATION_H */

--- a/core/include/tee/attestation.h
+++ b/core/include/tee/attestation.h
@@ -1,12 +1,15 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2017, Linaro Limited
+ * Copyright (c) Microsoft Corporation.
  */
 
 #ifndef __TEE_ATTESTATION_H
 #define __TEE_ATTESTATION_H
 
+#include <utee_defines.h>
+
 /* 
+ * Attestation:
  * Attestation of user TAs in OP-TEE is done via code measurement at load
  * time. If CFG_ATTESTATION_MEASURE is enabled the System PTA will request
  * a hash from the user TA store. Each time a new binary is loaded (ie 
@@ -16,10 +19,16 @@
  * copy of the running measurement is frozen before the first session to
  * the TA is opened.
  * 
+ * This static measurement is included in a x509 certificate signed by
+ * OP-TEE, along with other information. The measurement can also be used
+ * to create binary locked encrypted objects and derive additional keys.
+ *
  * Run Time Binary Loading:
  * The system PTA offers the option to load binaries after a TA has started
  * running (dlopen etc). This poses an interesting challenge for attestation
- * since the original measurement will no longer be valid.
+ * since the original measurement will no longer be valid. While the frozen
+ * measurement is always available, a dynamic measurement is also maintained
+ * which includes all dynamically loaded components.
  * 
  * TODO: Flesh out this description
  * 
@@ -28,13 +37,39 @@
  * - Inconsistent Measurements
  * Secstor and Ree FS TAs are not measured the same as Early TAs. Early TAs do
  * not include any headers when they are encoded into the OP-TEE binary and
- * are a simple hash over the .elf being loaded. The other user TA measurements
- * are based on the existing verification flow and include parts of the TA
- * headers.
+ * are a simple hash over the (default compressed) .elf being loaded. The
+ * other user TA measurements are based on the existing verification flow and
+ * include parts of the TA headers.
+ *
+ * - Measurements too early
+ * Ideally measurements should be taked during mapping of the TAs rather than
+ * during initial binary loading. The much simpler measurement is being used
+ * for version 1.
  * 
  */
+#ifdef CFG_ATTESTATION_MEASURE
 
 #define ATTESTATION_MEASUREMENT_SIZE TEE_SHA256_HASH_SIZE
 #define ATTESTATION_MEASUREMENT_ALGO TEE_ALG_SHA256
+/*
+ * struct tee_attestation_data - user TA attestation measurements
+ * @dynamic_measurement	A running hash of all binary components loaded,
+ *			including runtime dynamic libraries
+ * @static_measurement	A measurement of the TA as it existed when execution
+ *			started (first session start)
+ * @is_measured		True if the static measurement has been set
+ * @ta_version		The TA version as defined in the shdr_bootstrap_ta
+ *			bootstrap header
+ * @signer_measurement	Hash of the signing key used to verify the TA
+ */
+struct tee_attestation_data {
+	bool is_measured;
+	uint8_t dynamic_measurement[ATTESTATION_MEASUREMENT_SIZE];
+	uint8_t static_measurement[ATTESTATION_MEASUREMENT_SIZE];
+	uint32_t ta_version;
+	uint8_t signer_measurement[ATTESTATION_MEASUREMENT_SIZE];
+};
+
+#endif /* CFG_ATTESTATION_MEASURE */
 
 #endif /* __TEE_ATTESTATION_H */

--- a/core/include/tee/tadb.h
+++ b/core/include/tee/tadb.h
@@ -56,6 +56,17 @@ TEE_Result tee_tadb_ta_delete(const TEE_UUID *uuid);
 TEE_Result tee_tadb_ta_open(const TEE_UUID *uuid, struct tee_tadb_ta_read **ta);
 const struct tee_tadb_property *
 tee_tadb_ta_get_property(struct tee_tadb_ta_read *ta);
+
+#ifdef CFG_ATTESTATION_MEASURE
+TEE_Result tee_tadb_set_measurement(struct tee_tadb_ta_write *ta,
+				    uint8_t *measurement, size_t len,
+				    uint32_t algo);
+TEE_Result tee_tadb_get_measurement(struct tee_tadb_ta_read *ta,
+				    uint8_t *measurement,
+				    size_t *measurement_len);
+uint32_t tee_tadb_get_version(struct tee_tadb_ta_read *ta);
+#endif /*CFG_ATTESTATION_MEASURE*/
+
 TEE_Result tee_tadb_get_tag(struct tee_tadb_ta_read *ta, uint8_t *tag,
 			    unsigned int *tag_len);
 TEE_Result tee_tadb_ta_read(struct tee_tadb_ta_read *ta, void *buf,

--- a/core/pta/secstor_ta_mgmt.c
+++ b/core/pta/secstor_ta_mgmt.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <tee_api_types.h>
 #include <crypto/crypto.h>
+#include <tee/attestation.h>
 #include <tee/uuid.h>
 #include <types_ext.h>
 #include <utee_defines.h>
@@ -125,6 +126,13 @@ static TEE_Result install_ta(struct shdr *shdr, const uint8_t *nw,
 		res = TEE_ERROR_SECURITY;
 		goto err_ta_finalize;
 	}
+
+#ifdef CFG_ATTESTATION_MEASURE
+	/* Store the measurement for future attestation */
+	res = tee_tadb_set_measurement(ta, buf, shdr->hash_size, hash_algo);
+	if (res)
+		goto err_ta_finalize;
+#endif /* CFG_ATTESTATION_MEASURE */
 
 	crypto_hash_free_ctx(hash_ctx, hash_algo);
 	free(buf);

--- a/core/pta/system.c
+++ b/core/pta/system.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <tee_api_defines_extensions.h>
 #include <tee_api_defines.h>
+#include <tee/attestation.h>
 #include <util.h>
 
 #define MAX_ENTROPY_IN			32u
@@ -208,12 +209,127 @@ static void ta_bin_close(void *ptr)
 	free(binh);
 }
 
+#ifdef CFG_ATTESTATION_MEASURE
+/*
+ * User TAs are measured by repeatedly hashing the measurements of each
+ * component together. The measurement starts by copying the initial hash
+ * of the TA binary used for verification. The hash of each subsequent
+ * shared library is combined with the existing measurement.
+ *
+ * The order in which the binaries are loaded is important, re-ordering the
+ * loads will result in a different measurement.
+ *
+ * A static snapshot of the measurement is taken when the first session to a
+ * TA is opened. Any subsequent library loads during runtime will still be
+ * measured in the dynamic measurement, but will not be reflected in the
+ * static measurement.
+ */
+static TEE_Result update_measurements(const struct user_ta_store_ops *ta_store,
+				      struct user_ta_store_handle *handle,
+				      struct user_ta_ctx *utc)
+{
+	TEE_Result res = TEE_SUCCESS;
+	size_t buffer_len = 0;
+	void *hash_ctx = NULL;
+	uint8_t hash[ATTESTATION_MEASUREMENT_SIZE] = {0};
+
+	DMSG("Measuring binary %pUl ", (void *)&utc->ctx.uuid);
+	if (utc->is_measured)
+		EMSG("Warning: Measuring dynamic libraries with attestation!");
+
+	/*
+	 * If this is the first elf to be hashed, i.e. if the current
+	 * hash is zero, set the TA hash to the hash of this ELF. Initialize
+	 * constant measurement fields now.
+	 */
+	if (!memcmp(utc->dynamic_measurement, hash, sizeof(hash))) {
+		buffer_len = sizeof(utc->signer_measurement);
+		res = ta_store->get_signer(handle,
+					   utc->signer_measurement,
+					   &buffer_len);
+		if (res)
+			return res;
+
+		res = ta_store->get_version(handle, &utc->ta_version);
+		if (res)
+			return res;
+
+		buffer_len = sizeof(utc->dynamic_measurement);
+		res = ta_store->get_measurement(handle,
+						 utc->dynamic_measurement,
+						 &buffer_len);
+		DMSG("Initial measurement:");
+		DHEXDUMP(utc->dynamic_measurement,
+			 sizeof(utc->dynamic_measurement));
+		DMSG("Signer:");
+		DHEXDUMP(utc->signer_measurement,
+			 sizeof(utc->signer_measurement));
+		DMSG("Version:");
+		DHEXDUMP(&utc->ta_version, sizeof(utc->ta_version));
+		return res;
+	}
+
+	EMSG("Extending measurement");
+	DMSG("Initial measurement:");
+	DHEXDUMP(utc->dynamic_measurement, sizeof(utc->dynamic_measurement));
+
+	/* get hash for the elf that was just loaded */
+	buffer_len = sizeof(hash);
+	res = ta_store->get_measurement(handle, hash, &buffer_len);
+	if (res)
+		goto end;
+
+	res = crypto_hash_alloc_ctx(&hash_ctx, ATTESTATION_MEASUREMENT_ALGO);
+	if (res)
+		goto end;
+
+	res = crypto_hash_init(hash_ctx, ATTESTATION_MEASUREMENT_ALGO);
+	if (res)
+		goto end;
+
+	/* hash the existing value */
+	res = crypto_hash_update(hash_ctx, ATTESTATION_MEASUREMENT_ALGO,
+				 utc->dynamic_measurement,
+				 sizeof(utc->dynamic_measurement));
+	if (res)
+		goto end;
+
+	/* add the new value */
+	res = crypto_hash_update(hash_ctx, ATTESTATION_MEASUREMENT_ALGO,
+				 hash, sizeof(hash));
+	if (res)
+		goto end;
+
+	/* and write back to the TA hash */
+	res = crypto_hash_final(hash_ctx, ATTESTATION_MEASUREMENT_ALGO,
+				utc->dynamic_measurement,
+				sizeof(utc->dynamic_measurement));
+	if (res)
+		goto end;
+
+end:
+	if (hash_ctx)
+		crypto_hash_free_ctx(hash_ctx, ATTESTATION_MEASUREMENT_ALGO);
+
+	DMSG("Updated measurement:");
+	DHEXDUMP(utc->dynamic_measurement, sizeof(utc->dynamic_measurement));
+	DMSG("Signer:");
+	DHEXDUMP(utc->signer_measurement, sizeof(utc->signer_measurement));
+	DMSG("Version:");
+	DHEXDUMP(&utc->ta_version, sizeof(utc->ta_version));
+	return res;
+}
+#endif /* CFG_ATTESTATION_MEASURE */
+
 static TEE_Result system_open_ta_binary(struct system_ctx *ctx,
 					uint32_t param_types,
 					TEE_Param params[TEE_NUM_PARAMS])
 {
 	TEE_Result res = TEE_SUCCESS;
 	struct bin_handle *binh = NULL;
+#ifdef CFG_ATTESTATION_MEASURE
+	struct user_ta_ctx *caller_context = NULL;
+#endif
 	int h = 0;
 	TEE_UUID *uuid = NULL;
 	uint8_t tag[FILE_TAG_SIZE] = { 0 };
@@ -260,6 +376,13 @@ static TEE_Result system_open_ta_binary(struct system_ctx *ctx,
 	h = handle_get(&ctx->db, binh);
 	if (h < 0)
 		goto err_oom;
+
+#ifdef CFG_ATTESTATION_MEASURE
+	caller_context = to_user_ta_ctx(tee_ta_get_calling_session()->ctx);
+	res = update_measurements(binh->op, binh->h, caller_context);
+	if (res)
+		goto err;
+#endif
 
 	return TEE_SUCCESS;
 err_oom:

--- a/core/tee/tadb.c
+++ b/core/tee/tadb.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <tee_api_defines_extensions.h>
+#include <tee/attestation.h>
 #include <tee/tadb.h>
 #include <tee/tee_fs.h>
 #include <tee/tee_fs_rpc.h>
@@ -41,6 +42,8 @@ struct tadb_entry {
 	uint8_t iv[TADB_IV_SIZE];
 	uint8_t tag[TADB_TAG_SIZE];
 	uint8_t key[TADB_KEY_SIZE];
+	uint8_t measurement[ATTESTATION_MEASUREMENT_SIZE];
+	uint32_t measurement_algo;
 };
 
 struct tadb_header {
@@ -682,6 +685,45 @@ tee_tadb_ta_get_property(struct tee_tadb_ta_read *ta)
 {
 	return &ta->entry.prop;
 }
+
+#ifdef CFG_ATTESTATION_MEASURE
+TEE_Result tee_tadb_set_measurement(struct tee_tadb_ta_write *ta,
+				    uint8_t *measurement,
+				    size_t measurement_len,
+				    uint32_t algo)
+{
+	if (measurement_len != ATTESTATION_MEASUREMENT_SIZE ||
+	    algo != ATTESTATION_MEASUREMENT_ALGO)
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	memcpy(ta->entry.measurement, measurement,
+	       ATTESTATION_MEASUREMENT_SIZE);
+	ta->entry.measurement_algo = ATTESTATION_MEASUREMENT_ALGO;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result tee_tadb_get_measurement(struct tee_tadb_ta_read *ta,
+				    uint8_t *measurement,
+				    size_t *measurement_len)
+{
+	if (!measurement || *measurement_len < ATTESTATION_MEASUREMENT_SIZE) {
+		*measurement_len = ATTESTATION_MEASUREMENT_SIZE;
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+	*measurement_len = ATTESTATION_MEASUREMENT_SIZE;
+
+	memcpy(measurement, ta->entry.measurement,
+	       ATTESTATION_MEASUREMENT_SIZE);
+
+	return TEE_SUCCESS;
+}
+
+uint32_t tee_tadb_get_version(struct tee_tadb_ta_read *ta)
+{
+	return ta->entry.prop.version;
+}
+#endif /* CFG_ATTESTATION_MEASURE */
 
 TEE_Result tee_tadb_get_tag(struct tee_tadb_ta_read *ta, uint8_t *tag,
 			    unsigned int *tag_len)

--- a/core/tee/tadb.c
+++ b/core/tee/tadb.c
@@ -42,8 +42,10 @@ struct tadb_entry {
 	uint8_t iv[TADB_IV_SIZE];
 	uint8_t tag[TADB_TAG_SIZE];
 	uint8_t key[TADB_KEY_SIZE];
+#ifdef CFG_ATTESTATION_MEASURE
 	uint8_t measurement[ATTESTATION_MEASUREMENT_SIZE];
 	uint32_t measurement_algo;
+#endif
 };
 
 struct tadb_header {

--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -8,10 +8,14 @@ TA_SIGN_KEY ?= $(ta-dev-kit-dir$(sm))/keys/default_ta.pem
 all: $(link-out-dir$(sm))/$(user-ta-uuid).dmp \
 	$(link-out-dir$(sm))/$(user-ta-uuid).stripped.elf \
 	$(link-out-dir$(sm))/$(user-ta-uuid).ta
+ifeq ($(CFG_ATTESTATION_MEASURE),y)
+all: $(link-out-dir$(sm))/$(user-ta-uuid).dig
+endif
 cleanfiles += $(link-out-dir$(sm))/$(user-ta-uuid).elf
 cleanfiles += $(link-out-dir$(sm))/$(user-ta-uuid).dmp
 cleanfiles += $(link-out-dir$(sm))/$(user-ta-uuid).map
 cleanfiles += $(link-out-dir$(sm))/$(user-ta-uuid).stripped.elf
+cleanfiles += $(link-out-dir$(sm))/$(user-ta-uuid).dig
 cleanfiles += $(link-out-dir$(sm))/$(user-ta-uuid).ta
 cleanfiles += $(link-script-pp$(sm)) $(link-script-dep$(sm))
 
@@ -71,6 +75,14 @@ $(link-out-dir$(sm))/$(user-ta-uuid).stripped.elf: \
 			$(link-out-dir$(sm))/$(user-ta-uuid).elf
 	@$(cmd-echo-silent) '  OBJCOPY $$@'
 	$(q)$(OBJCOPY$(sm)) --strip-unneeded $$< $$@
+
+ifeq ($(CFG_ATTESTATION_MEASURE),y)
+$(link-out-dir$(sm))/$(user-ta-uuid).dig: $(link-out-dir$(sm))/$(user-ta-uuid).stripped.elf \
+				$(TA_SIGN_KEY)
+	@$(cmd-echo-silent) '  MEASURE $$@'
+	$(q)$(SIGN) digest --key $(TA_SIGN_KEY) --uuid $(user-ta-uuid) \
+		--in $$< --dig $$@
+endif
 
 $(link-out-dir$(sm))/$(user-ta-uuid).ta: \
 			$(link-out-dir$(sm))/$(user-ta-uuid).stripped.elf \

--- a/ta/arch/arm/link_shlib.mk
+++ b/ta/arch/arm/link_shlib.mk
@@ -10,10 +10,14 @@ all: $(link-out-dir)/$(shlibname).so $(link-out-dir)/$(shlibname).dmp \
 	$(link-out-dir)/$(shlibname).stripped.so \
 	$(link-out-dir)/$(shlibuuid).elf \
 	$(link-out-dir)/$(shlibuuid).ta
+ifeq ($(CFG_ATTESTATION_MEASURE),y)
+all: $(link-out-dir)/$(shlibuuid).dig
+endif
 
 cleanfiles += $(link-out-dir)/$(shlibname).so
 cleanfiles += $(link-out-dir)/$(shlibname).dmp
 cleanfiles += $(link-out-dir)/$(shlibname).stripped.so
+cleanfiles += $(link-out-dir)/$(shlibuuid).dig
 cleanfiles += $(link-out-dir)/$(shlibuuid).elf
 cleanfiles += $(link-out-dir)/$(shlibuuid).ta
 
@@ -38,6 +42,14 @@ $(link-out-dir)/$(shlibname).dmp: $(link-out-dir)/$(shlibname).so
 $(link-out-dir)/$(shlibname).stripped.so: $(link-out-dir)/$(shlibname).so
 	@$(cmd-echo-silent) '  OBJCOPY $@'
 	$(q)$(OBJCOPY$(sm)) --strip-unneeded $< $@
+
+ifeq ($(CFG_ATTESTATION_MEASURE),y)
+$(link-out-dir)/$(shlibuuid).dig: $(link-out-dir)/$(shlibname).stripped.so \
+				$(TA_SIGN_KEY)
+	@$(cmd-echo-silent) '  MEASURE    $@'
+	$(q)$(SIGN) digest --key $(TA_SIGN_KEY) --uuid $(shlibuuid) \
+		--in $< --dig $@
+endif
 
 $(link-out-dir)/$(shlibuuid).elf: $(link-out-dir)/$(shlibname).so
 	@$(cmd-echo-silent) '  LN      $@'


### PR DESCRIPTION
Initial draft of measurement.

Issues:
- Need to fill in more comments etc.
- Need to decide how to handle early TA vs normal user TAs having different hashing methods (probably just re-hash them all the same way, currently the user TAs also include their headers but the early TAs don't have headers)
